### PR TITLE
Use singular to_unit in System.convert_time_unit/3

### DIFF
--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -60,7 +60,7 @@ defmodule Salemove.HttpClient.Middleware.Logger do
 
   defp elapsed_ms(from) do
     now = System.monotonic_time()
-    us = System.convert_time_unit(now - from, :native, :microseconds)
+    us = System.convert_time_unit(now - from, :native, :microsecond)
     :io_lib.format("~.3f", [us / 1000])
   end
 


### PR DESCRIPTION
Plural to_unit is deprecated in newer elixir versions.