### PR TITLE
Fix error decoding to work correctly with Tesla 1.x

### DIFF
--- a/lib/salemove/http_client/decoder.ex
+++ b/lib/salemove/http_client/decoder.ex
@@ -14,7 +14,7 @@ defmodule Salemove.HttpClient.Decoder do
   alias Salemove.HttpClient.UnavailableError
   alias Salemove.HttpClient.UnsupportedProtocolError
 
-  @type tesla_result :: {:ok, Tesla.Env.t()} | {:error, %Tesla.Error{}}
+  @type tesla_result :: {:ok, Tesla.Env.t()} | {:error, reason :: any}
   @type on_decode :: {:ok, Response.t()} | {:error, reason}
   @type reason ::
           JSONError.t()
@@ -36,12 +36,12 @@ defmodule Salemove.HttpClient.Decoder do
     decode_env(env)
   end
 
-  def decode({:error, %Tesla.Error{} = error}) do
+  def decode({:error, {Tesla.Middleware.JSON, :decode, %Jason.DecodeError{} = error}}) do
     decode_error(error)
   end
 
-  def decode({:error, {Tesla.Middleware.JSON, :decode, %Jason.DecodeError{} = error}}) do
-    decode_error(error)
+  def decode({:error, reason}) do
+    decode_error(reason)
   end
 
   ##
@@ -61,7 +61,7 @@ defmodule Salemove.HttpClient.Decoder do
     {:error, %JSONError{reason: Exception.message(error)}}
   end
 
-  defp decode_error(%Tesla.Error{reason: reason}) do
+  defp decode_error(reason) do
     {:error, %ConnectionError{reason: reason}}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/test/salemove/http_client_test.exs
+++ b/test/salemove/http_client_test.exs
@@ -94,12 +94,9 @@ defmodule Salemove.HttpClientTest do
     @tag capture_log: true
     test "returns {:error, %ConnectionError{}} when adapter throws an error" do
       error_reason = :econnrefused
-      env = %Tesla.Env{}
-
-      exception = %Tesla.Error{env: env, reason: error_reason}
 
       allow_http_request(fn _env ->
-        {:error, exception}
+        {:error, error_reason}
       end)
 
       assert {:error, error} = TestClient.get("/test")
@@ -124,7 +121,7 @@ defmodule Salemove.HttpClientTest do
         else
           send(self_pid, :connection_refused_received)
 
-          {:error, %Tesla.Error{env: env, reason: error_reason}}
+          {:error, error_reason}
         end
       end)
 


### PR DESCRIPTION
Since release of 1.0, Tesla no longer wraps connection errors into
`%Tesla.Error{}` structs.