### PR TITLE
Log all errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+  * Bug fixes
+    * Fix a case when specific request failure errors were not logged
+
 ## v2.0.0
   * Breaking changes
     * Module config is now deep merged with base salemove_http_client config.

--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -37,17 +37,18 @@ defmodule Salemove.HttpClient.Middleware.Logger do
 
       {:ok, env}
     else
-      {:error, %Tesla.Error{} = ex} ->
-        _ = log(env, ex, elapsed_ms(time_start), opts)
-        {:error, ex}
-
       {:error, error} ->
+        log(env, error, elapsed_ms(time_start), opts)
         {:error, error}
     end
   end
 
   defp log(env, %Tesla.Error{reason: reason}, elapsed_ms, opts) do
     log_status(0, "#{normalize_method(env)} #{env.url} -> #{inspect(reason)} (#{elapsed_ms} ms)", opts)
+  end
+
+  defp log(env, error, elapsed_ms, opts) do
+    log_status(0, "#{normalize_method(env)} #{env.url} -> #{inspect(error)} (#{elapsed_ms} ms)", opts)
   end
 
   defp log(env, elapsed_ms, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Currently we do not log error in the last case. This case cause an error
to go unnoticed in case there is a retry middleware and the error
disappears.

We are had cases when 2 requests were made but only one of them was
logged, so this may help with debugging that case.