### PR TITLE
Reduce log level of a request timeout to [warn]

### DIFF
--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -43,6 +43,11 @@ defmodule Salemove.HttpClient.Middleware.Logger do
     end
   end
 
+  defp log(env, %Tesla.Error{reason: :timeout}, elapsed_ms, _opts) do
+    message = "#{normalize_method(env)} #{env.url} -> :timeout (#{elapsed_ms} ms)"
+    Logger.log(:warn, message)
+  end
+
   defp log(env, %Tesla.Error{reason: reason}, elapsed_ms, opts) do
     log_status(0, "#{normalize_method(env)} #{env.url} -> #{inspect(reason)} (#{elapsed_ms} ms)", opts)
   end

--- a/test/salemove/http_client/middleware/logger_test.exs
+++ b/test/salemove/http_client/middleware/logger_test.exs
@@ -17,6 +17,9 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
         "/connection-error" ->
           {:error, %Tesla.Error{env: env, reason: :econnrefused}}
 
+        "/timeout" ->
+          {:error, %Tesla.Error{env: env, reason: :timeout}}
+
         "/unexpected-error" ->
           {:error, "unexpected error"}
 
@@ -66,6 +69,12 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
       end)
 
     assert log =~ "/connection-error -> :econnrefused"
+  end
+
+  test "timeout" do
+    log = capture_log(fn -> Client.get("/timeout") end)
+    assert log =~ "/timeout -> :timeout"
+    assert log =~ "[warn]"
   end
 
   test "server error" do


### PR DESCRIPTION
Currently, timeouts are logged as errors. This needlessly captures
attention in the logs, but does not mean that anything has actually
failed yet.
In a distributed system, timeouts are inevitable and are usually
just retried.

Here, we reduce the log level of all timeouts to "warn".