### PR TITLE
Change log level to [warn] for `:closed` reason

### DIFF
--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -48,6 +48,11 @@ defmodule Salemove.HttpClient.Middleware.Logger do
     Logger.log(:warn, message)
   end
 
+  defp log(env, %Tesla.Error{reason: :closed}, elapsed_ms, _opts) do
+    message = "#{normalize_method(env)} #{env.url} -> :closed (#{elapsed_ms} ms)"
+    Logger.log(:warn, message)
+  end
+
   defp log(env, %Tesla.Error{reason: reason}, elapsed_ms, opts) do
     log_status(0, "#{normalize_method(env)} #{env.url} -> #{inspect(reason)} (#{elapsed_ms} ms)", opts)
   end

--- a/test/salemove/http_client/middleware/logger_test.exs
+++ b/test/salemove/http_client/middleware/logger_test.exs
@@ -20,6 +20,9 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
         "/timeout" ->
           {:error, %Tesla.Error{env: env, reason: :timeout}}
 
+        "/closed" ->
+          {:error, %Tesla.Error{env: env, reason: :closed}}
+
         "/unexpected-error" ->
           {:error, "unexpected error"}
 
@@ -74,6 +77,12 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
   test "timeout" do
     log = capture_log(fn -> Client.get("/timeout") end)
     assert log =~ "/timeout -> :timeout"
+    assert log =~ "[warn]"
+  end
+
+  test "closed" do
+    log = capture_log(fn -> Client.get("/closed") end)
+    assert log =~ "/closed -> :closed"
     assert log =~ "[warn]"
   end
 


### PR DESCRIPTION
Currently requests failing with `:closed` are logged as errors. This creates a lot of error noise.

Now we log those as level `:warn` instead of `:error`.