### PR TITLE
Log timeout and closed errors as warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.1.2
+  * Bug fixes
+    * Fix log levels of requests that end with `:timeout` or `:closed` from
+      "error" to "warn"
+
 ## v2.1.1
   * Bug fixes
     * Reduce log level of closed request from "error" to "warn"

--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -43,12 +43,12 @@ defmodule Salemove.HttpClient.Middleware.Logger do
     end
   end
 
-  defp log(env, %Tesla.Error{reason: :timeout}, elapsed_ms, _opts) do
+  defp log(env, :timeout, elapsed_ms, _opts) do
     message = "#{normalize_method(env)} #{env.url} -> :timeout (#{elapsed_ms} ms)"
     Logger.log(:warn, message)
   end
 
-  defp log(env, %Tesla.Error{reason: :closed}, elapsed_ms, _opts) do
+  defp log(env, :closed, elapsed_ms, _opts) do
     message = "#{normalize_method(env)} #{env.url} -> :closed (#{elapsed_ms} ms)"
     Logger.log(:warn, message)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "2.1.1",
+      version: "2.1.2",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/test/salemove/http_client/middleware/logger_test.exs
+++ b/test/salemove/http_client/middleware/logger_test.exs
@@ -18,10 +18,10 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
           {:error, %Tesla.Error{env: env, reason: :econnrefused}}
 
         "/timeout" ->
-          {:error, %Tesla.Error{env: env, reason: :timeout}}
+          {:error, :timeout}
 
         "/closed" ->
-          {:error, %Tesla.Error{env: env, reason: :closed}}
+          {:error, :closed}
 
         "/unexpected-error" ->
           {:error, "unexpected error"}


### PR DESCRIPTION
Connection errors are not wrapped into `%Tesla.Error{}` structs anymore, as noted already in commit da1b40d039e82c54af68c4585dca2d38e3ce165d. We are currently seeing error logs for both `:timeout` and `:closed`, when they should be warn logs. Tesla returns them as `{:error, reason}`.

MED-225