### PR TITLE
Add CHANGELOG.md to ExDoc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule Salemove.HttpClient.Mixfile do
       package: package(),
       description: description(),
       docs: [
-        main: "Salemove.HttpClient"
+        main: "Salemove.HttpClient",
+        extras: ["CHANGELOG.md"]
       ],
       dialyzer: [
         plt_add_apps: [:ex_unit],


### PR DESCRIPTION
This will show the CHANGELOG in the generated ExDoc documentation as well.

![image](https://user-images.githubusercontent.com/9250552/194878398-7f895007-4a45-4fa0-b48a-8951aa330bd8.png)
