### PR TITLE
Add support for HTTP_PROXY/NO_PROXY environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.10'
-              otp: '23.2'
-          - pair:
-              elixir: '1.11'
-              otp: '23.2'
-          - pair:
               elixir: '1.12'
-              otp: '24.1'
+              otp: '24.3'
+          - pair:
+              elixir: '1.13'
+              otp: '24.3'
+          - pair:
+              elixir: '1.14'
+              otp: '24.3'
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.1
+erlang 24.3
 elixir 1.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.0
+  * Enhancements
+    * Add support for HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
+
 ## v2.1.2
   * Bug fixes
     * Fix log levels of requests that end with `:timeout` or `:closed` from

--- a/lib/salemove/http_client/adapter.ex
+++ b/lib/salemove/http_client/adapter.ex
@@ -9,19 +9,9 @@ defmodule Salemove.HttpClient.Adapter do
   """
 
   @doc false
-  # executed as middleware
-  def call(env, next, opts) do
-    env
-    |> Tesla.put_opt(:__adapter, Keyword.fetch!(opts, :adapter))
-    |> Tesla.put_opt(:__adapter_options, Keyword.get(opts, :adapter_options, []))
-    |> Tesla.run(next)
-  end
-
-  @doc false
-  # executed as adapter
   def call(%{opts: opts} = env, _opts) do
-    adapter = Keyword.fetch!(opts, :__adapter)
-    adapter_options = Keyword.get(opts, :__adapter_options, [])
+    adapter = Keyword.fetch!(opts, :adapter)
+    adapter_options = Keyword.get(opts, :adapter_options, [])
 
     adapter.call(env, adapter_options)
   end

--- a/lib/salemove/http_client/middleware/proxy.ex
+++ b/lib/salemove/http_client/middleware/proxy.ex
@@ -1,0 +1,98 @@
+defmodule Salemove.HttpClient.Middleware.Proxy do
+  @behaviour Tesla.Middleware
+
+  @moduledoc """
+  Adds proxy server options to a request if either of the following conditions are met:
+  * Environment variable `http_proxy` (or `HTTP_PROXY`) is set and requested protocol is `http://`
+  * Environment variable `https_proxy` (or `HTTPS_PROXY`) is set and requested protocol is `https://`
+
+  Proxy options are not injected if either of the following conditions are met:
+  * Requested host is included into `no_proxy` (or `NO_PROXY`) environment variable
+  * Http client is configured with option `proxy: false`
+  """
+
+  def call(env, next, opts) do
+    if Keyword.get(opts, :proxy, []) do
+      env
+      |> inject_proxy(opts)
+      |> Tesla.run(next)
+    else
+      Tesla.run(env, next)
+    end
+  end
+
+  # The code below is copied from https://github.com/edgurgel/httpoison/blob/fa2238cfb9833776e5eebdb2d73d0e1a0093a356/lib/httpoison/base.ex#L818-L851
+
+  defp inject_proxy(env, opts) do
+    proxy =
+      if Keyword.has_key?(opts, :proxy) do
+        Keyword.get(opts, :proxy) |> check_no_proxy(env.url)
+      else
+        case URI.parse(env.url).scheme do
+          "http" -> System.get_env("HTTP_PROXY") || System.get_env("http_proxy")
+          "https" -> System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
+          _ -> nil
+        end
+        |> check_no_proxy(env.url)
+      end
+
+    proxy_options =
+      opts
+      |> Keyword.take(~w[proxy_auth socks5_user socks5_pass]a)
+      |> Keyword.put(:proxy, proxy)
+
+    new_options =
+      Keyword.update(opts, :adapter_options, proxy_options, fn adapter_options ->
+        adapter_options ++ proxy_options
+      end)
+
+    %{env | opts: new_options}
+  end
+
+  defp check_no_proxy(nil, _) do
+    # Don't bother to check no_proxy if there's no proxy to use anyway.
+    nil
+  end
+
+  defp check_no_proxy(proxy, request_url) do
+    request_host = URI.parse(request_url).host
+
+    should_bypass_proxy =
+      get_no_proxy_system_env()
+      |> String.split(",")
+      |> Enum.any?(fn domain -> matches_no_proxy_value?(request_host, String.trim(domain)) end)
+
+    if should_bypass_proxy do
+      nil
+    else
+      proxy
+    end
+  end
+
+  defp get_no_proxy_system_env() do
+    System.get_env("NO_PROXY") || System.get_env("no_proxy") || ""
+  end
+
+  defp matches_no_proxy_value?(request_host, no_proxy_value) do
+    cond do
+      no_proxy_value == "" ->
+        false
+
+      String.starts_with?(no_proxy_value, ".") ->
+        String.ends_with?(request_host, no_proxy_value) || request_host == String.trim_leading(no_proxy_value, ".")
+
+      String.contains?(no_proxy_value, "*") ->
+        matches_wildcard?(request_host, no_proxy_value)
+
+      true ->
+        request_host == no_proxy_value
+    end
+  end
+
+  defp matches_wildcard?(request_host, wildcard_domain) do
+    Regex.escape(wildcard_domain)
+    |> String.replace("\\*", ".*")
+    |> Regex.compile!()
+    |> Regex.match?(request_host)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "2.1.2",
+      version: "2.2.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/test/salemove/http_client/middleware/logger_test.exs
+++ b/test/salemove/http_client/middleware/logger_test.exs
@@ -77,13 +77,13 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
   test "timeout" do
     log = capture_log(fn -> Client.get("/timeout") end)
     assert log =~ "/timeout -> :timeout"
-    assert log =~ "[warn]"
+    assert log =~ ~r/\[warn(ing)?\]/
   end
 
   test "closed" do
     log = capture_log(fn -> Client.get("/closed") end)
     assert log =~ "/closed -> :closed"
-    assert log =~ "[warn]"
+    assert log =~ ~r/\[warn(ing)?\]/
   end
 
   test "server error" do
@@ -105,7 +105,7 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
   test "client error with custom log level option supplied as range" do
     log = capture_log(fn -> Client.get("/teapot") end)
     assert log =~ "/teapot -> 418"
-    assert log =~ "warn"
+    assert log =~ ~r/\[warn(ing)?\]/
   end
 
   test "unexpected error" do

--- a/test/salemove/http_client/middleware/proxy_test.exs
+++ b/test/salemove/http_client/middleware/proxy_test.exs
@@ -1,0 +1,86 @@
+defmodule Salemove.HttpClient.Middleware.ProxyTest do
+  use Salemove.HttpClientCase, async: false
+
+  alias Salemove.HttpClient
+
+  defmodule DefaultClient do
+    use Salemove.HttpClient, base_url: "http://test-api/"
+  end
+
+  setup do
+    allow_http_request(fn env ->
+      env
+      |> status(200)
+      |> json(%{})
+    end)
+
+    on_exit(fn ->
+      System.delete_env("HTTP_PROXY")
+      System.delete_env("HTTPS_PROXY")
+      System.delete_env("NO_PROXY")
+    end)
+  end
+
+  describe "when client configured proxy on module level" do
+    defmodule ProxyClient do
+      use Salemove.HttpClient,
+        base_url: "http://test-api/",
+        proxy: "http://127.0.0.1:3128/"
+    end
+
+    test "sends requests through HTTP proxy" do
+      {:ok, _} = ProxyClient.get("/test")
+      assert_requested(env)
+
+      assert env.opts[:adapter_options][:proxy] == "http://127.0.0.1:3128/"
+    end
+  end
+
+  describe "when client configured proxy via environment variables" do
+    @http_proxy "http://127.0.0.1:3128/"
+    @https_proxy "https://127.0.0.1:3128/"
+
+    test "doesn't use proxy by default" do
+      env = get("/test")
+      assert is_nil(env.opts[:adapter_options][:proxy])
+    end
+
+    test "uses proxy from HTTP_PROXY environment variable when protocol is HTTP" do
+      System.put_env("HTTP_PROXY", @http_proxy)
+      System.put_env("HTTPS_PROXY", @https_proxy)
+
+      env = get("/test")
+      assert env.opts[:adapter_options][:proxy] == @http_proxy
+    end
+
+    test "uses proxy from HTTPS_PROXY environment variable when protocol is HTTPS" do
+      System.put_env("HTTP_PROXY", @http_proxy)
+      System.put_env("HTTPS_PROXY", @https_proxy)
+
+      env = get("https://test-api/test")
+      assert env.opts[:adapter_options][:proxy] == @https_proxy
+    end
+
+    test "ignores proxy when the host is included into NO_PROXY environment variable" do
+      System.put_env("HTTP_PROXY", @http_proxy)
+      System.put_env("HTTPS_PROXY", @https_proxy)
+      System.put_env("NO_PROXY", "localhost,.test-api")
+
+      env = get("https://test-api/test")
+      assert is_nil(env.opts[:adapter_options][:proxy])
+
+      env = get("http://localhost/test")
+      assert is_nil(env.opts[:adapter_options][:proxy])
+
+      env = get("http://example.com/test")
+      assert env.opts[:adapter_options][:proxy] == @http_proxy
+    end
+
+    defp get(url) do
+      {:ok, _} = DefaultClient.get(url)
+      assert_requested(env)
+
+      env
+    end
+  end
+end


### PR DESCRIPTION
Environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY are pretty
standard and understood by most HTTP-client libraries in popular
languages and packages (Ruby, Python, Java, Go, curl).

This commit adds support for these environment variables without
attempting being too clever.

When implementing we mostly followed recommendations from [this article][1],
but without adding support for CIDR block matching in NO_PROXY variable.

This implementation mostly copies the logic from [httpoison][2] library and
should be good enough for most use cases.

[1]: https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
[2]: https://github.com/edgurgel/httpoison