### PR TITLE
Log 5xx as warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4.0
+* Enhancements
+  * Changes log levels of requests that fail with 5XX from "error" to "warn"
+
 ## v2.3.0
 * Enhancements
     * Include method, path, status and duration in logger metadata

--- a/lib/salemove/http_client/middleware/logger.ex
+++ b/lib/salemove/http_client/middleware/logger.ex
@@ -113,6 +113,7 @@ defmodule Salemove.HttpClient.Middleware.Logger do
 
   defp status_to_level(status, _) do
     cond do
+      status >= 500 -> :warn
       status >= 400 || status == 0 -> :error
       status >= 300 -> :warn
       true -> :info

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "2.3.0",
+      version: "2.4.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,

--- a/test/salemove/http_client/middleware/logger_test.exs
+++ b/test/salemove/http_client/middleware/logger_test.exs
@@ -97,6 +97,7 @@ defmodule Salemove.HttpClient.Middleware.LoggerTest do
   test "server error" do
     log = capture_log(fn -> Client.get("/server-error") end)
     assert log =~ "/server-error -> 500"
+    assert log =~ ~r/\[warn(ing)?\]/
   end
 
   test "client error" do


### PR DESCRIPTION
5xx is a server error and should not be logged as error on the client
side.

This causes a lot of error noise.