### PR TITLE
Publish using updated version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish package to hex.pm
-        uses: wesleimp/action-publish-hex@ae719f0fead451221d2ca0127c0aae70c5f90b4c
+        uses: salemove/action-publish-hex@v1
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
Publishing did not work any more when we bumped minimum Elixir version. 
We forked `wesleimp/action-publish-hex` repository and brought it under salemove. 
Now we use updated version of it that uses Elixir 1.15.

MED-679