### PR TITLE
Get default values at runtime

### DIFF
--- a/lib/salemove/http_client.ex
+++ b/lib/salemove/http_client.ex
@@ -83,7 +83,6 @@ defmodule Salemove.HttpClient do
     ],
     retry: false
   ]
-  @application_defaults Keyword.merge(@hardcoded_defaults, Application.get_all_env(:salemove_http_client) || [])
 
   use Tesla,
     # don't generate GET/POST/... functions for HttpClient module
@@ -113,7 +112,9 @@ defmodule Salemove.HttpClient do
   end
 
   defp build_client(options) do
-    @application_defaults
+    application_defaults = Keyword.merge(@hardcoded_defaults, Application.get_all_env(:salemove_http_client) || [])
+
+    application_defaults
     |> Keyword.merge(options, &deep_merge/3)
     |> Confex.Resolver.resolve!()
     |> build_stack()


### PR DESCRIPTION
Currently configuration values are fetched at compile-time. When a developer changes the configuration of `:salemove_http_client` in their service, only the service code gets recompiled. `:salemove_http_client` does not get recompiled. This creates confusing situations where it's not clear why changes to the configuration do not take effect.

Getting the values at runtime ensures that these sorts of issues do not happen.

The alternative was to keep using compile-time values and use `Application.compile_env/4` to retrieve them. However, this would still create confusing error messages for developers and would require that people recompile this dependency by hand. Retrieving values at run-time seems like a better approach to me.