### PR TITLE
Make tesla_statsd dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v5.0.0
+* Breaking changes
+  * `tesla_statsd` is now an optional dependency. If you want to use the StatsD
+    integration, then you need to add `tesla_statsd` to your application
+    dependencies in `mix.exs` and enable it via the `stats` configuration
+    field.
+
 ## v4.0.0
 * Breaking changes
   * Disabled `StatsD` integration by default. It can still be enabled and

--- a/lib/salemove/http_client.ex
+++ b/lib/salemove/http_client.ex
@@ -25,7 +25,9 @@ defmodule Salemove.HttpClient do
     * `:json` - JSON encoding/decoding options. If omitted, default options are used - see `Tesla.Middleware.JSON`.
       If set to `false`, request body is sent as application/x-www-form-urlencoded not JSON.
     * `:retry` - Retry few times in case of connection refused error. See `Tesla.Middleware.Retry`.
-    * `:stats` - StatsD instrumenting options. See `Tesla.StatsD` for more details.
+    * `:stats` - StatsD instrumenting options. The `:tesla_statsd` dependency
+      must be included in your service to use this option. See `Tesla.StatsD`
+      for more details.
     * `:username` - along with `:password` option adds basic authentication to all requests.
       See `Tesla.Middleware.BasicAuth`.
     * `:password` - see `:username`.
@@ -122,7 +124,9 @@ defmodule Salemove.HttpClient do
 
   defp build_stack(options) do
     encode_json_enabled = Keyword.get(options, :json, true)
+
     stats_enabled = Keyword.get(options, :stats, false)
+    if stats_enabled, do: Code.ensure_loaded!(Tesla.StatsD)
 
     []
     |> push_middleware(Salemove.HttpClient.Middleware.MapHeaders)

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Salemove.HttpClient.Mixfile do
   defp deps do
     [
       {:tesla, "~> 1.4"},
-      {:tesla_statsd, "~> 0.4.0"},
+      {:tesla_statsd, "~> 0.4.0", optional: true},
       {:confex, "~> 3.0"},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:opentelemetry_tesla, "~> 2.0", optional: true},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Salemove.HttpClient.Mixfile do
   def project do
     [
       app: :salemove_http_client,
-      version: "4.0.0",
+      version: "5.0.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Since 603e6aa ("Disable StatsD integration by default", 2024-04-15), the
dependency will not actually be used by default. It will only be used if
`:stats` are explicitly enabled.

Having the dependency always included causes some problems for another
metrics library which is meant to essentially replace `tesla_statsd` by
using `Tesla`'s `:telemetry` integration. The problem is that both
libraries use `statix` but define different constraints which causes a
conflict.

By making the dependency optional we can still allow the user of the
library to choose the behavior they want but we can also make other,
`:telemetry`-based libraries work seamlessly without requiring
dependency overrides.

[1]: https://github.com/salemove/glia-elixir-utils/tree/master/glia_metrics
